### PR TITLE
Fix Issue with Featured Image

### DIFF
--- a/article.php
+++ b/article.php
@@ -4,8 +4,8 @@
 		
 	<article class="article-post">
 	
-		<?php if(article_custom_field('featured-image')): ?>
-		<div class="featured-image" style="background-image: url(<?php echo article_custom_field('featured-image', 'http://s13.postimg.org/w3p4tc5pz/article_img_default.jpg'); ?>);">
+		<?php if(article_custom_field('featured_image')): ?>
+		<div class="featured-image" style="background-image: url(<?php echo article_custom_field('featured_image', 'http://s13.postimg.org/w3p4tc5pz/article_img_default.jpg'); ?>);">
 			<div class="overlay"></div>
 			
 				<?php if(article_custom_field('featured-image-credit')): ?>


### PR DESCRIPTION
For some reason, when creating the Featured Image custom field, every time I set the unique key to featured-image it would switch to feature_image after I saved it.  I am not sure, but I assuming that there have been some changes to the anchorcms code that may produce this issue.  I was able to fix this on my build (0.9.2) by changing the featured-image to featured_image in 2 spots.
