### PR TITLE
Fix Featured Image fields

### DIFF
--- a/article.php
+++ b/article.php
@@ -4,12 +4,12 @@
 		
 	<article class="article-post">
 	
-		<?php if(article_custom_field('featured-image')): ?>
-		<div class="featured-image" style="background-image: url(<?php echo article_custom_field('featured-image', 'http://s13.postimg.org/w3p4tc5pz/article_img_default.jpg'); ?>);">
+		<?php if(article_custom_field('featured_image')): ?>
+		<div class="featured-image" style="background-image: url(<?php echo article_custom_field('featured_image', 'http://s13.postimg.org/w3p4tc5pz/article_img_default.jpg'); ?>);">
 			<div class="overlay"></div>
 			
-				<?php if(article_custom_field('featured-image-credit')): ?>
-				<div class="featured-image__credit"><?php echo article_custom_field('featured-image-credit'); ?></div>
+				<?php if(article_custom_field('featured_image_credit')): ?>
+				<div class="featured-image__credit"><?php echo article_custom_field('featured_image_credit'); ?></div>
 				<?php endif; ?>
 			
 				<header class="post-header">


### PR DESCRIPTION
Anchor defaults hyphens in custom fields to underscores, which breaks the functionality. Modified to use underscores.
